### PR TITLE
Making Modals not under the color editor

### DIFF
--- a/src/components/ModalContainer.vue
+++ b/src/components/ModalContainer.vue
@@ -55,5 +55,6 @@ export default {
   display:table-cell;
   vertical-align:middle;
   overflow:auto;
+  z-index: 10;
 }
 </style>


### PR DESCRIPTION
**Bug:** Modals are under color editor
**Reproduce:**
 - Open Color editor
 - Open a modal such a convert
![Capture](https://user-images.githubusercontent.com/1678699/78020198-48d9cd00-7351-11ea-8079-0ad691d68cf6.PNG)
