### PR TITLE
Added CIELAB conversion support to the image loader

### DIFF
--- a/src/components/ImageLoader.vue
+++ b/src/components/ImageLoader.vue
@@ -31,7 +31,7 @@
           <li :class="{active: convert_method === 'quantize'}" @click="changeConversion('quantize')">Quantize by Median-Cut</li>
           <li :class="{active: convert_method === 'rgb'}" @click="changeConversion('rgb')">Nearest RGB Colors</li>
           <li :class="{active: convert_method === 'yuv'}" @click="changeConversion('yuv')">Nearest YUV Colors</li>
-	  <li :class="{active: convert_method === 'lab'}" @click="changeConversion('lab')">Nearest CIELAB Colors</li>
+          <li :class="{active: convert_method === 'lab'}" @click="changeConversion('lab')">Nearest CIELAB Colors</li>
           <li :class="{active: convert_method === 'grey'}" @click="changeConversion('grey')">To Greyscale</li>
           <li :class="{active: convert_method === 'sepia'}" @click="changeConversion('sepia')">To Sepia</li>
         </ul>
@@ -139,7 +139,7 @@ export default {
           case "quantize": this.image_quantize(imgdata); break;
           case "rgb": this.image_rgb(imgdata); break;
           case "yuv": this.image_yuv(imgdata); break;
-	  case "lab": this.image_lab(imgdata); break;
+          case "lab": this.image_lab(imgdata); break;
           case "grey": this.image_grey(imgdata); break;
           case "sepia": this.image_sepia(imgdata); break;
           case "keep": this.image_keep(imgdata); break;

--- a/src/components/ImageLoader.vue
+++ b/src/components/ImageLoader.vue
@@ -31,6 +31,7 @@
           <li :class="{active: convert_method === 'quantize'}" @click="changeConversion('quantize')">Quantize by Median-Cut</li>
           <li :class="{active: convert_method === 'rgb'}" @click="changeConversion('rgb')">Nearest RGB Colors</li>
           <li :class="{active: convert_method === 'yuv'}" @click="changeConversion('yuv')">Nearest YUV Colors</li>
+		  <li :class="{active: convert_method === 'lab'}" @click="changeConversion('lab')">Nearest CIELAB Colors</li>
           <li :class="{active: convert_method === 'grey'}" @click="changeConversion('grey')">To Greyscale</li>
           <li :class="{active: convert_method === 'sepia'}" @click="changeConversion('sepia')">To Sepia</li>
         </ul>
@@ -138,6 +139,7 @@ export default {
           case "quantize": this.image_quantize(imgdata); break;
           case "rgb": this.image_rgb(imgdata); break;
           case "yuv": this.image_yuv(imgdata); break;
+		  case "lab": this.image_lab(imgdata); break;
           case "grey": this.image_grey(imgdata); break;
           case "sepia": this.image_sepia(imgdata); break;
           case "keep": this.image_keep(imgdata); break;
@@ -154,6 +156,7 @@ export default {
               case "quantize": this.image_quantize(imgdata); break;
               case "rgb": this.image_rgb(imgdata); break;
               case "yuv": this.image_yuv(imgdata); break;
+              case "lab": this.image_lab(imgdata); break;
               case "grey": this.image_grey(imgdata); break;
               case "sepia": this.image_sepia(imgdata); break;
               case "keep": this.image_keep(imgdata); break;
@@ -207,6 +210,22 @@ export default {
         palette[this.draw.findYUV([imgdata.data[i], imgdata.data[i+1], imgdata.data[i+2]])].c++;
       }
       palette.sort(function(a, b){
+        if (a.c > b.c){return -1;}
+        if (a.c < b.c){return 1;}
+        return 0;
+      });
+      for (let i = 0; i < 15; i++){this.draw.setPalette(i, palette[i].n);}
+    },
+	//Sets the palette to the top-15 closest LAB colors
+    image_lab(imgdata){
+      let palette = [];
+      for (let i = 0; i < 256; i++){palette.push({n: i, c:0});}
+      const pixelCount = imgdata.data.length;
+      for (let i = 0; i < pixelCount; i+=4){
+        if (imgdata.data[i+3] < this.convert_trans*2.55){continue;}
+        palette[this.draw.findLAB([imgdata.data[i], imgdata.data[i+1], imgdata.data[i+2]])].c++;
+      }
+      palette.sort((a, b) => {
         if (a.c > b.c){return -1;}
         if (a.c < b.c){return 1;}
         return 0;

--- a/src/components/ImageLoader.vue
+++ b/src/components/ImageLoader.vue
@@ -31,7 +31,7 @@
           <li :class="{active: convert_method === 'quantize'}" @click="changeConversion('quantize')">Quantize by Median-Cut</li>
           <li :class="{active: convert_method === 'rgb'}" @click="changeConversion('rgb')">Nearest RGB Colors</li>
           <li :class="{active: convert_method === 'yuv'}" @click="changeConversion('yuv')">Nearest YUV Colors</li>
-		  <li :class="{active: convert_method === 'lab'}" @click="changeConversion('lab')">Nearest CIELAB Colors</li>
+	  <li :class="{active: convert_method === 'lab'}" @click="changeConversion('lab')">Nearest CIELAB Colors</li>
           <li :class="{active: convert_method === 'grey'}" @click="changeConversion('grey')">To Greyscale</li>
           <li :class="{active: convert_method === 'sepia'}" @click="changeConversion('sepia')">To Sepia</li>
         </ul>
@@ -139,7 +139,7 @@ export default {
           case "quantize": this.image_quantize(imgdata); break;
           case "rgb": this.image_rgb(imgdata); break;
           case "yuv": this.image_yuv(imgdata); break;
-		  case "lab": this.image_lab(imgdata); break;
+	  case "lab": this.image_lab(imgdata); break;
           case "grey": this.image_grey(imgdata); break;
           case "sepia": this.image_sepia(imgdata); break;
           case "keep": this.image_keep(imgdata); break;

--- a/src/libs/ACNLFormat.js
+++ b/src/libs/ACNLFormat.js
@@ -419,7 +419,7 @@ for (let i = 0; i < 256; i++){
   if (m.length < 7){
     ACNLFormat.RGBLookup.push(null);
     ACNLFormat.YUVLookup.push(null);
-	ACNLFormat.LABLookup.push(null);
+    ACNLFormat.LABLookup.push(null);
   }else{
     let rgb = [parseInt(m.substr(1, 2), 16), parseInt(m.substr(3, 2), 16), parseInt(m.substr(5, 2), 16)];
     ACNLFormat.RGBLookup.push(rgb);

--- a/src/libs/DrawingTool.js
+++ b/src/libs/DrawingTool.js
@@ -329,7 +329,7 @@ class DrawingTool{
   /// Finds the closest LAB global palette index we can find to the color c
   /// Supports [r,g,b]-style only.
   findLAB(rgb) {
-	rgb = [rgb[0]/255,rgb[1]/255,rgb[2]/255]; //Equations require RGB values to be a real number ranging from 0-1
+    rgb = [rgb[0]/255,rgb[1]/255,rgb[2]/255]; //Equations require RGB values to be a real number ranging from 0-1
     //Convert to XYZ from sRGB before converting to LAB
     let xyz;
     let lab;
@@ -385,7 +385,7 @@ class DrawingTool{
   /// Finds the closest LAB current palette index we can find to the color c
   /// Supports [r,g,b]-style only.
   findPalLAB(rgb) {
-	rgb = [rgb[0]/255,rgb[1]/255,rgb[2]/255]; //Equations require RGB values to be a real number ranging from 0-1
+    rgb = [rgb[0]/255,rgb[1]/255,rgb[2]/255]; //Equations require RGB values to be a real number ranging from 0-1
     //Convert to XYZ from sRGB before converting to LAB
     let xyz;
     let lab;


### PR DESCRIPTION
This adds support for the CIELAB color space and makes it accessible through the image loader dialog box.

CIELAB was developed so that the euclidean distance between colors pertains to the perceived difference between them. You can read up on it more [here](https://en.wikipedia.org/wiki/CIELAB_color_space).

CIELAB provides a competitive edge over the RGB and YUV modes in that the difference between two colors within this space is uniform to how we perceive color differences in real life. RGB and YUV differences lack this quality and can often yield undesirable or mediocre results.

This will give the user another option to choose from and compare against the others.

A downside of this method is that it's more complex and computationally expensive than the other two methods. I haven't noticed a slowdown on my machine, so this is just something to look out for.

Attached are tons of converted samples and a screenshot of the dialog box.

![dialog](https://user-images.githubusercontent.com/55416123/78618670-3bd54600-7849-11ea-9c29-fdfb9159f923.png)
![fox_original](https://user-images.githubusercontent.com/55416123/78618672-3c6ddc80-7849-11ea-8af8-4bf1005f9e22.png)
![fox_rgb](https://user-images.githubusercontent.com/55416123/78618675-3d067300-7849-11ea-8034-a3ebad777152.png)
![fox_yuv](https://user-images.githubusercontent.com/55416123/78618676-3d067300-7849-11ea-8789-eaae2099f11c.png)
![fox_lab](https://user-images.githubusercontent.com/55416123/78618671-3c6ddc80-7849-11ea-8f8e-5f01294622ae.png)
![rainbowisabelle_original](https://user-images.githubusercontent.com/55416123/78618678-3d9f0980-7849-11ea-8c4b-8c3dc5ef912b.png)
![rainbowisabelle_rgb](https://user-images.githubusercontent.com/55416123/78618679-3d9f0980-7849-11ea-8792-f253b23cccaa.png)
![rainbowisabelle_yuv](https://user-images.githubusercontent.com/55416123/78618680-3e37a000-7849-11ea-90a7-c993579b0596.png)
![rainbowisabelle_lab](https://user-images.githubusercontent.com/55416123/78618677-3d9f0980-7849-11ea-9292-a12199fe8e9e.png)
![smpte_original](https://user-images.githubusercontent.com/55416123/78618682-3ed03680-7849-11ea-89e8-c906b1863def.png)
![smpte_rgb](https://user-images.githubusercontent.com/55416123/78618683-3ed03680-7849-11ea-8cd2-6d864fc0911e.png)
![smpte_yuv](https://user-images.githubusercontent.com/55416123/78618686-3f68cd00-7849-11ea-857e-3fcfc1160890.png)
![smpte_lab](https://user-images.githubusercontent.com/55416123/78618681-3e37a000-7849-11ea-861d-53b131e7dfca.png)