### PR TITLE
Fixed a bug: Corrected the props name "defaultPosition" in imageLoader.vue

### DIFF
--- a/src/components/ImageLoader.vue
+++ b/src/components/ImageLoader.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="cropper-container" v-show="isCropping">
       <button v-show="!fileLoaded" @click="tryAgain">Upload an Image File</button>
-      <div class="outercropper"><Cropper :src="dataurl" :stencilProps="{aspectRatio: getAspectRatio()}" :defaultPositon="defPos" :defaultSize="defSize" ref="cropper" @change="onCrop" /></div>
+      <div class="outercropper"><Cropper :src="dataurl" :stencilProps="{aspectRatio: getAspectRatio()}" :defaultPosition="defPos" :defaultSize="defSize" ref="cropper" @change="onCrop" /></div>
       <div class="muralInputArea" :v-if="patternType == 9">
         <div class="muralInputColumn"> 
           <label>Patterns Wide</label></br>


### PR DESCRIPTION
I found a spelling mistake  in src/components/imageLoader.vue and corrected it.

"Vue Advanced Cropper" component (Cropper tag) has the props "defaultPosition", not "defaultPositon". Details are below. 
https://norserium.github.io/vue-advanced-cropper/components/cropper.html#props
